### PR TITLE
Fix broken slides link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 
-Find slides [here](http://kcd.im/react-mocha)
+Find slides [here](https://kcd.im/testing-react)
 
 This is a workshop for learning how to test [React][React] with the [Mocha][Mocha] testing framework and the
 [Enzyme][Enzyme] testing library. It also uses [Chai][Chai] for helpful assertions


### PR DESCRIPTION
The previous link was going to http://kcd.im/react-mocha, which is broken. Did you mean to link it to your slides.com presentation at https://kcd.im/testing-react?
